### PR TITLE
fix: remove useless key

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -59,7 +59,6 @@ class _DemoPageState extends State<DemoPage> {
               children: <Widget>[
                 (imagePrecached == true)
                     ? ImageView360(
-                        key: UniqueKey(),
                         imageList: imageList,
                         autoRotate: autoRotate,
                         rotationCount: rotationCount,

--- a/lib/imageview360.dart
+++ b/lib/imageview360.dart
@@ -33,7 +33,7 @@ class ImageView360 extends StatefulWidget {
   final Function(int? currentImageIndex)? onImageIndexChanged;
 
   ImageView360({
-    required Key key,
+    Key? key,
     required this.imageList,
     this.autoRotate = false,
     this.allowSwipeToRotate = true,
@@ -42,7 +42,7 @@ class ImageView360 extends StatefulWidget {
     this.rotationDirection = RotationDirection.clockwise,
     this.frameChangeDuration = const Duration(milliseconds: 80),
     this.onImageIndexChanged,
-  }) : super(key: key);
+  });
 
   @override
   _ImageView360State createState() => _ImageView360State();


### PR DESCRIPTION
Hello,

We can remove the required `key` parameter, it's not used in the library.